### PR TITLE
Deployment fix and some suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 config.json
 *.pyc
 *.iml
+ansible/my-inventory

--- a/README.md
+++ b/README.md
@@ -86,13 +86,7 @@ changed: [my_raspi_host]
 TASK [Reboot the machine when /boot/config.txt was changed] *************************
 changed: [my_raspi_host]
 
-PLAY [Clone MFRC522-trigger from github] ********************************************
-
-TASK [Create devel directory] *******************************************************
-changed: [my_raspi_host]
-
-TASK [Clone MFRC522-trigger from github] ********************************************
-changed: [my_raspi_host]
+PLAY [Init MFRC522-trigger in devel directory] **************************************
 
 TASK [Copy config.json from sample file] ********************************************
 changed: [my_raspi_host]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ enable_uart=1
 * Ansible is an automation tool, if you wanna know more about it have a look at 
   https://docs.ansible.com/ansible/latest/index.html
 * install Ansible on your local machine https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
+* The automated install assumes that you have a /boot/userconfig.txt that is included from /boot/config. This is the default-setup for volumio3 distributions. Otherwise add include userconfig.txt to the end of /boot/config.txt or modify ansible/MFRC522-trigger.yml to modify /etc/config instead od /etc/userconfig.txt
 * on your local machine clone the repo https://github.com/layereight/MFRC522-trigger to a direcory named 'devel' (or adjust folder in MFRC522-trigger.yml)
 ```
 $ mkdir devel

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ enable_uart=1
 # Automated Installation
 
 * all the steps from the manual installation can be done automatically
-* automated installation is achieved using [Ansible](https://docs.ansible.com/ansible/latest/index.html)
+* automated installation is achieved by using [Ansible](https://docs.ansible.com/ansible/latest/index.html)
 * Ansible is an automation tool, if you wanna know more about it have a look at 
   https://docs.ansible.com/ansible/latest/index.html
 * install Ansible on your local machine https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
@@ -52,7 +52,8 @@ $ mkdir devel
 $ cd devel
 $ git clone https://github.com/layereight/MFRC522-trigger.git
 $ cd MFRC522-trigger/ansible
-$ vi inventory
+$ cp inventory my-inventory
+$ vi my-inventory
 ```
 * replace the contents of the file *inventory* to point to your music box (e.g. my_raspi_host)
 * since this contains your password it is recommended that you *copy* inventory to a new file *my-inventory* (which is ignopred from git) so you don't accidentally push your settings

--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ $ cd MFRC522-trigger/ansible
 $ vi inventory
 ```
 * replace the contents of the file *inventory* to point to your music box (e.g. my_raspi_host)
+* since this contains your password it is recommended that you *copy* inventory to a new file *my-inventory* (which is ignopred from git) so you don't accidentally push your settings
 ```
 [my_pi]
 my_raspi_host ansible_host=192.168.1.100 ansible_user=pi ansible_ssh_pass=raspberry
 ```
 * execute the ansible playbook, it runs for roughly 10 minutes, so go grab a coffee ;-)
 ```
-$ ansible-playbook -i inventory MFRC522-trigger.yml 
+$ ansible-playbook -i my-inventory MFRC522-trigger.yml 
 
 PLAY [Install prerequisite software] ************************************************
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ enable_uart=1
 * Ansible is an automation tool, if you wanna know more about it have a look at 
   https://docs.ansible.com/ansible/latest/index.html
 * install Ansible on your local machine https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
-* on your local machine clone the repo https://github.com/layereight/MFRC522-trigger
+* on your local machine clone the repo https://github.com/layereight/MFRC522-trigger to a direcory named 'devel' (or adjust folder in MFRC522-trigger.yml)
 ```
+$ mkdir devel
+$ cd devel
 $ git clone https://github.com/layereight/MFRC522-trigger.git
 $ cd MFRC522-trigger/ansible
 $ vi inventory

--- a/ansible/MFRC522-trigger.yml
+++ b/ansible/MFRC522-trigger.yml
@@ -50,28 +50,28 @@
         name: pi-rc522
         executable: pip3
 
-- name: Prepare Raspberry Pi's /boot/config.txt
+- name: Prepare Raspberry Pi's /boot/userconfig.txt
   hosts: my_pi
   gather_facts: false
-  tags: [ boot_config ]
+  tags: [ boot_userconfig ]
 
   tasks:
 
-    - name: Alter /boot/config.txt
+    - name: Alter /boot/userconfig.txt
       become: yes
       blockinfile:
-        path: /boot/config.txt
-        insertbefore: "#### Volumio i2s setting below: do not alter ####"
+        path: /boot/userconfig.txt
+        insertbefore: "# Add your custom config.txt options to this file, which will be preserved during updates"
         content: |
           dtparam=spi=on
           dtoverlay=pi3-disable-bt
           enable_uart=1
-      register: boot_config
+      register: boot_userconfig
 
-    - name: Reboot the machine when /boot/config.txt was changed
+    - name: Reboot the machine when /boot/userconfig.txt was changed
       become: yes
       reboot:
-      when: boot_config.changed == true
+      when: boot_userconfig.changed == true
 
 - name: Clone MFRC522-trigger from github
   hosts: my_pi

--- a/ansible/MFRC522-trigger.yml
+++ b/ansible/MFRC522-trigger.yml
@@ -61,12 +61,11 @@
       become: yes
       blockinfile:
         path: /boot/userconfig.txt
-        insertbefore: "# Add your custom config.txt options to this file, which will be preserved during updates"
+        insertafter: "# Add your custom config.txt options to this file, which will be preserved during updates"
         marker: "# {mark} ansible manged for MFRC522-trigger"
         content: |
           dtparam=spi=on
           dtoverlay=pi3-disable-bt
-          enable_uart=1
       register: boot_userconfig
 
     - name: Reboot the machine when /boot/userconfig.txt was changed

--- a/ansible/MFRC522-trigger.yml
+++ b/ansible/MFRC522-trigger.yml
@@ -66,6 +66,7 @@
         content: |
           dtparam=spi=on
           dtoverlay=pi3-disable-bt
+          enable_uart=1 # just to enable power status led on pin 5 (GPIO 3)
       register: boot_userconfig
 
     - name: Reboot the machine when /boot/userconfig.txt was changed

--- a/ansible/MFRC522-trigger.yml
+++ b/ansible/MFRC522-trigger.yml
@@ -85,7 +85,7 @@
   tasks:
     - name: Copy config.json from sample file
       copy:
-        src: "{{ target_dir }}/config.json.sample"
+        src: "{{ target_dir }}/config.sample.json"
         remote_src: yes
         dest: "{{ target_dir }}/config.json"
         force: no

--- a/ansible/MFRC522-trigger.yml
+++ b/ansible/MFRC522-trigger.yml
@@ -62,6 +62,7 @@
       blockinfile:
         path: /boot/userconfig.txt
         insertbefore: "# Add your custom config.txt options to this file, which will be preserved during updates"
+        marker: "# {mark} ansible manged for MFRC522-trigger"
         content: |
           dtparam=spi=on
           dtoverlay=pi3-disable-bt

--- a/ansible/MFRC522-trigger.yml
+++ b/ansible/MFRC522-trigger.yml
@@ -73,7 +73,7 @@
       reboot:
       when: boot_userconfig.changed == true
 
-- name: Clone MFRC522-trigger from github
+- name: Init MFRC522-trigger in devel directory
   hosts: my_pi
   gather_facts: false
   tags: [ clone ]
@@ -83,18 +83,6 @@
     target_dir: "devel/MFRC522-trigger"
 
   tasks:
-
-    - name: Create devel directory
-      file:
-        path: devel
-        state: directory
-
-    - name: Clone MFRC522-trigger from github
-      git:
-        repo: "https://github.com/layereight/MFRC522-trigger.git"
-        dest: "{{ target_dir }}"
-        force: yes
-
     - name: Copy config.json from sample file
       copy:
         src: "{{ target_dir }}/config.json.sample"


### PR DESCRIPTION
fixed
- name of config-sample file in playbook now matches sample file in repo

These changes might be helfpful for others, too:
- removed cloning of repo from the same repro (found it slightly confusing)
- introduced my-inventory to avoid accidentally pushing modified inventory
- moved changes from /boot/config.txt to /boot/userconfig.txt matching volumio3 distribution